### PR TITLE
Use the standard Python __str__ instead of `print()`

### DIFF
--- a/traintest.py
+++ b/traintest.py
@@ -10,41 +10,41 @@ class TrainTest(unittest.TestCase):
     
     def test_passenger_train(self):
         train = Train("HPP")
-        self.assertEqual("<HHHH::|OOOO|::|OOOO|", train.print())
+        self.assertEqual("<HHHH::|OOOO|::|OOOO|", str(train))
 
     def test_restaurant_train(self):
         train = Train("HPRP")
-        self.assertEquals("<HHHH::|OOOO|::|hThT|::|OOOO|", train.print())
+        self.assertEquals("<HHHH::|OOOO|::|hThT|::|OOOO|", str(train))
 
     def test_double_headed_train(self):
         train = Train("HPRPH")
-        self.assertEquals("<HHHH::|OOOO|::|hThT|::|OOOO|::HHHH>", train.print())
+        self.assertEquals("<HHHH::|OOOO|::|hThT|::|OOOO|::HHHH>", str(train))
 
     def test_modify_train(self):
         train = Train("HPRPH")
         train.detachEnd()
-        self.assertEquals("<HHHH::|OOOO|::|hThT|::|OOOO|", train.print())
+        self.assertEquals("<HHHH::|OOOO|::|hThT|::|OOOO|", str(train))
         train.detachHead()
-        self.assertEquals("|OOOO|::|hThT|::|OOOO|", train.print())
+        self.assertEquals("|OOOO|::|hThT|::|OOOO|", str(train))
 
     def test_cargo_train(self):
         train = Train("HCCC")
-        self.assertEquals("<HHHH::|____|::|____|::|____|", train.print())
+        self.assertEquals("<HHHH::|____|::|____|::|____|", str(train))
         train.fill()
-        self.assertEquals("<HHHH::|^^^^|::|____|::|____|", train.print())
+        self.assertEquals("<HHHH::|^^^^|::|____|::|____|", str(train))
         train.fill()
-        self.assertEquals("<HHHH::|^^^^|::|^^^^|::|____|", train.print())
+        self.assertEquals("<HHHH::|^^^^|::|^^^^|::|____|", str(train))
         train.fill()
-        self.assertEquals("<HHHH::|^^^^|::|^^^^|::|^^^^|", train.print())
+        self.assertEquals("<HHHH::|^^^^|::|^^^^|::|^^^^|", str(train))
         self.assertFalse(train.fill())
 
     def test_mixed_train(self):
         train = Train("HPCPC")
-        self.assertEquals("<HHHH::|OOOO|::|____|::|OOOO|::|____|", train.print())
+        self.assertEquals("<HHHH::|OOOO|::|____|::|OOOO|::|____|", str(train))
         train.fill()
-        self.assertEquals("<HHHH::|OOOO|::|^^^^|::|OOOO|::|____|", train.print())
+        self.assertEquals("<HHHH::|OOOO|::|^^^^|::|OOOO|::|____|", str(train))
         train.fill()
-        self.assertEquals("<HHHH::|OOOO|::|^^^^|::|OOOO|::|^^^^|", train.print())
+        self.assertEquals("<HHHH::|OOOO|::|^^^^|::|OOOO|::|^^^^|", str(train))
         self.assertFalse(train.fill())
 
 if __name__ == '__main__':


### PR DESCRIPTION
As pointed out by Riccardo, print is a reserved word in Python 2.x. And
using __str__ is more "pythonic"...